### PR TITLE
Fix ts3 URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ ksp_installer
 -------------
 This scripts searches for an existing KSP Installation in the current dir or at Path given as commandline argument.
 If no KSP executable is found it will try to download the newest release from https://kerbalspaceprogram.com.
-You will be ask for your KSP Store login credentials (if correct, the will saved in YOUR copy of this script).
-After extracting to desired Path, it applys the patch against segfaults, creates a launch script with the right language enviroment and a program starter with icon.
+You will be ask for your KSP Store login credentials (if correct, they will saved in YOUR copy of this script).
+After extracting to the desired Path, it applys the patch against segfaults, creates a launch script with the right language enviroment and a program starter with icon.
 
-Dependencies: aside from standard *nix tools, xxd (included in the vim project) and perl required for binary patching
+Dependencies: aside from standard *nix tools, `xxd` (included in the vim project) and `perl` are required for binary patching
 ```
 wget https://raw.githubusercontent.com/Voidi/proprietary_installer/master/ksp_installer
 chmod u+x ksp_installer
@@ -19,7 +19,7 @@ teamspeak3_installer
 -------------
 This scripts searches for an existing TeamSpeak3 Client Installation in the current dir or at Path given as commandline argument.
 If no TeamSpeak3 Client executable is found it will try to download the newest release from https://dl.4players.de.
-After extracting to desired Path, creates a program starter with icon.
+After extracting to the desired Path, it creates a program starter with icon.
 ```
 wget https://raw.githubusercontent.com/Voidi/proprietary_installer/master/teamspeak3_installer
 chmod u+x teamspeak3_installer


### PR DESCRIPTION
Pointed to KSP instead of 4players.de
Might be better to point to teamspeak.com, tho
